### PR TITLE
Refonte des en-têtes de sections Favoris et Onglets

### DIFF
--- a/sidebar.css
+++ b/sidebar.css
@@ -1,3 +1,5 @@
+/* /Users/tandreu/StudioProjects/NewArche/sidebar.css */
+
 /* Thème clair (défaut) */
 :root {
   --color-background: #f8f9fa;
@@ -146,6 +148,57 @@ html, body {
   letter-spacing: 0.5px;
   flex-shrink: 0;
 }
+
+/* NOUVEAUX STYLES POUR LE TITRE DES FAVORIS */
+#bookmarks-header {
+  margin: 2px 4px;
+  padding: 8px 12px;
+  border-radius: 4px;
+  border-bottom: none;
+  background-color: var(--color-background-tertiary);
+  color: var(--color-text);
+  font-weight: 500;
+  text-transform: none;
+  letter-spacing: normal;
+  cursor: pointer;
+  transition: background-color 0.2s;
+  /* MODIFICATION : Ajustement des propriétés flex pour l'alignement à gauche */
+  display: flex;
+  justify-content: flex-start; /* Aligne les items au début */
+  align-items: center;
+  gap: 8px; /* Ajoute un espace entre le chevron et le texte */
+}
+
+#bookmarks-header:hover {
+  background-color: var(--color-background-secondary);
+}
+
+.chevron::before {
+  content: '▼'; /* Flèche vers le bas par défaut */
+  font-size: 10px;
+  color: var(--color-text-secondary);
+  padding: 4px;
+  display: inline-block; /* Pour un meilleur contrôle de l'alignement */
+  width: 1em; /* Assure une largeur constante */
+  text-align: center;
+}
+
+/* STYLES POUR L'ÉTAT PLIÉ */
+.newarche-bookmarks-container.collapsed {
+  height: auto !important; /* Important pour outrepasser le style en ligne JS */
+  flex-shrink: 0;
+}
+
+.newarche-bookmarks-container.collapsed .chevron::before {
+  content: '►'; /* Flèche vers la droite quand plié */
+}
+
+.newarche-bookmarks-container.collapsed > .newarche-bookmarks,
+.newarche-bookmarks-container.collapsed ~ #newarche-resizer {
+  display: none;
+}
+/* FIN DES NOUVEAUX STYLES */
+
 
 .newarche-section-title button {
   padding: 2px 8px;

--- a/sidebar.css
+++ b/sidebar.css
@@ -134,43 +134,50 @@ html, body {
 }
 
 /* Titres de section */
+/* Style générique pour tous les titres de section, qui est ensuite surchargé */
 .newarche-section-title {
   padding: 12px;
-  background-color: var(--color-background);
-  border-bottom: 1px solid var(--color-border);
   font-weight: 600;
   color: var(--color-text-secondary);
   display: flex;
-  justify-content: space-between;
   align-items: center;
   font-size: 13px;
-  text-transform: uppercase;
-  letter-spacing: 0.5px;
   flex-shrink: 0;
 }
 
-/* NOUVEAUX STYLES POUR LE TITRE DES FAVORIS */
-#bookmarks-header {
+/* STYLE PARTAGÉ pour les en-têtes de section cliquables */
+#bookmarks-header,
+#tabs-header {
   margin: 2px 4px;
   padding: 8px 12px;
   border-radius: 4px;
-  border-bottom: none;
   background-color: var(--color-background-tertiary);
   color: var(--color-text);
   font-weight: 500;
-  text-transform: none;
-  letter-spacing: normal;
   cursor: pointer;
   transition: background-color 0.2s;
-  /* MODIFICATION : Ajustement des propriétés flex pour l'alignement à gauche */
-  display: flex;
-  justify-content: flex-start; /* Aligne les items au début */
-  align-items: center;
-  gap: 8px; /* Ajoute un espace entre le chevron et le texte */
 }
 
-#bookmarks-header:hover {
+#bookmarks-header {
+  justify-content: flex-start;
+  gap: 8px;
+}
+
+#tabs-header {
+  justify-content: flex-start; /* Aligne les items à gauche */
+  gap: 8px; /* Ajoute un espace entre l'icône et le texte */
+}
+
+#bookmarks-header:hover,
+#tabs-header:hover {
   background-color: var(--color-background-secondary);
+}
+
+/* Style de l'icône "+" */
+.add-icon {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
 }
 
 .chevron::before {
@@ -178,14 +185,14 @@ html, body {
   font-size: 10px;
   color: var(--color-text-secondary);
   padding: 4px;
-  display: inline-block; /* Pour un meilleur contrôle de l'alignement */
-  width: 1em; /* Assure une largeur constante */
+  display: inline-block;
+  width: 1em;
   text-align: center;
 }
 
 /* STYLES POUR L'ÉTAT PLIÉ */
 .newarche-bookmarks-container.collapsed {
-  height: auto !important; /* Important pour outrepasser le style en ligne JS */
+  height: auto !important;
   flex-shrink: 0;
 }
 
@@ -197,21 +204,7 @@ html, body {
 .newarche-bookmarks-container.collapsed ~ #newarche-resizer {
   display: none;
 }
-/* FIN DES NOUVEAUX STYLES */
 
-
-.newarche-section-title button {
-  padding: 2px 8px;
-  background: var(--color-accent);
-  color: var(--color-accent-text);
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-size: 14px;
-}
-.newarche-section-title button:hover {
-  background: var(--color-accent-hover);
-}
 
 /* Listes */
 .newarche-bookmarks,

--- a/sidebar.html
+++ b/sidebar.html
@@ -41,7 +41,10 @@
       <div class="newarche-resizer" id="newarche-resizer"></div>
       
       <div class="newarche-tabs-container">
-        <div class="newarche-section-title">Onglets <button id="newarche-new-tab" title="Nouvel onglet">+</button></div>
+        <div id="tabs-header" class="newarche-section-title">
+          <span class="add-icon">+</span>
+          <span>Nouvel Onglet</span>
+        </div>
         <div class="newarche-tabs" id="newarche-tabs"><div class="newarche-loading">Chargement...</div></div>
       </div>
     </div>

--- a/sidebar.html
+++ b/sidebar.html
@@ -31,7 +31,10 @@
       </div>
       
       <div class="newarche-bookmarks-container">
-        <div class="newarche-section-title">Favoris</div>
+        <div id="bookmarks-header" class="newarche-section-title">
+          <span class="chevron"></span>
+          <span>Favoris</span>
+        </div>
         <div class="newarche-bookmarks" id="newarche-bookmarks"><div class="newarche-loading">Chargement...</div></div>
       </div>
       

--- a/sidebar.js
+++ b/sidebar.js
@@ -1,3 +1,5 @@
+// /Users/tandreu/StudioProjects/NewArche/sidebar.js
+
 // --- Références aux éléments du DOM ---
 const sidebarElement = document.getElementById('newarche-sidebar');
 const navBackBtn = document.getElementById('nav-back');
@@ -9,6 +11,7 @@ const bookmarksList = document.getElementById('newarche-bookmarks');
 const tabsList = document.getElementById('newarche-tabs');
 const resizer = document.getElementById('newarche-resizer');
 const bookmarksContainer = document.querySelector('.newarche-bookmarks-container');
+const bookmarksHeader = document.getElementById('bookmarks-header');
 
 
 // --- GESTION DU THÈME (CORRIGÉE AVEC L'APPROCHE HYBRIDE) ---
@@ -65,8 +68,16 @@ async function initialize() {
     // On lance la mise à jour du thème sans attendre pour ne pas bloquer le reste.
     updateTheme();
     
-    const data = await browser.storage.local.get('bookmarkHeight');
+    const data = await browser.storage.local.get(['bookmarkHeight', 'bookmarksCollapsed']);
+    
+    // Appliquer la hauteur sauvegardée
     bookmarksContainer.style.height = `${data.bookmarkHeight || 50}%`;
+    
+    // Appliquer l'état plié/déplié sauvegardé
+    if (data.bookmarksCollapsed) {
+        bookmarksContainer.classList.add('collapsed');
+    }
+    
     attachEventListeners();
     await refreshAllLists();
 }
@@ -77,6 +88,9 @@ function attachEventListeners() {
     // On écoute les deux types de changements de thème.
     browser.theme.onUpdated.addListener(updateTheme);
     window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', updateTheme);
+
+    // Ajout de l'écouteur pour plier/déplier les favoris
+    bookmarksHeader.addEventListener('click', toggleBookmarks);
 
     navBackBtn.addEventListener('click', async () => {
         const [activeTab] = await browser.tabs.query({ active: true, currentWindow: true });
@@ -119,6 +133,12 @@ function attachEventListeners() {
     browser.bookmarks.onRemoved.addListener(debouncedRefresh);
     
     initializeResizer();
+}
+
+// --- Nouvelle fonction pour gérer le pliage des favoris ---
+async function toggleBookmarks() {
+    const isCollapsed = bookmarksContainer.classList.toggle('collapsed');
+    await browser.storage.local.set({ bookmarksCollapsed: isCollapsed });
 }
 
 

--- a/sidebar.js
+++ b/sidebar.js
@@ -6,12 +6,12 @@ const navBackBtn = document.getElementById('nav-back');
 const navForwardBtn = document.getElementById('nav-forward');
 const navReloadBtn = document.getElementById('nav-reload');
 const urlInput = document.getElementById('newarche-url-input');
-const newTabBtn = document.getElementById('newarche-new-tab');
 const bookmarksList = document.getElementById('newarche-bookmarks');
 const tabsList = document.getElementById('newarche-tabs');
 const resizer = document.getElementById('newarche-resizer');
 const bookmarksContainer = document.querySelector('.newarche-bookmarks-container');
 const bookmarksHeader = document.getElementById('bookmarks-header');
+const tabsHeader = document.getElementById('tabs-header'); // Nouvelle référence
 
 
 // --- GESTION DU THÈME (CORRIGÉE AVEC L'APPROCHE HYBRIDE) ---
@@ -121,7 +121,8 @@ function attachEventListeners() {
     };
     urlInput.addEventListener('keydown', (e) => { if (e.key === 'Enter') navigate(); });
 
-    newTabBtn.addEventListener('click', () => browser.tabs.create({}));
+    // Remplacement de l'ancien bouton par le nouvel en-tête cliquable
+    tabsHeader.addEventListener('click', () => browser.tabs.create({}));
 
     const debouncedRefresh = debounce(refreshAllLists, 150);
     browser.tabs.onUpdated.addListener(debouncedRefresh);
@@ -282,7 +283,7 @@ async function displayTabs(appState, allTabs) {
 function isValidHttpUrl(string) {
     try {
         const url = new URL(string);
-        return url.protocol === "http:" || url.protocol === "https:";
+        return url.protocol === "http:" || url.protocol === "https:"
     } catch (_) {
         return false;
     }


### PR DESCRIPTION
Meilleur interface du volet latéral en améliorant l'interactivité et la cohérence visuelle des en-têtes de sections.
Changements apportés :
Section "Favoris"
L'en-tête a été redessiné pour correspondre au style des éléments de la liste.
Il est maintenant cliquable et permet de masquer/afficher la liste des favoris.
Un chevron (►/▼) à gauche indique l'état (plié/déplié).
L'état est sauvegardé dans le storage local et restauré à la réouverture du volet.
Section "Nouvel Onglet"
L'en-tête de la section "Onglets" a été transformé en un bouton "Nouvel Onglet", adoptant le même style que l'en-tête des favoris pour une meilleure cohérence visuelle.
Un clic sur cet en-tête ouvre directement un nouvel onglet, remplaçant l'ancien bouton +.
Une icône + plus grande est intégrée à gauche du texte pour une meilleure affordance.